### PR TITLE
Add pyrefly config

### DIFF
--- a/pyre.toml
+++ b/pyre.toml
@@ -1,0 +1,25 @@
+# pyre.toml
+
+project_includes = ["./**/*.py"]
+
+project_excludes = [
+  "**/node_modules/**",
+  "**/__pycache__/**",
+  "**/.git/**",
+  "**/venv/**",
+  "**/.venv/**",
+  "typeshed/**",
+  "tests/test_files/**"
+]
+
+site_package_path = [
+  ".venv/Lib/site-packages"
+]
+
+[errors]
+bad_assignment = false
+missing_attribute = false
+bad_specialization = false
+bad_argument_type = false
+internal_error = false
+bad_return = false


### PR DESCRIPTION
Testing this project with Pyrefly

`pip install pyrefly`

`pyrefly check --config pyre.toml`

Error output since Pypi doesn't have the latest version supporting suppressions

[missing-attribute] - 14 https://github.com/facebook/pyrefly/issues/42
[internal-error] - 10 https://github.com/facebook/pyrefly/issues/41
[bad-assignment] - 8
[bad-argument-type] - 4
[bad-specialization] - 1
[bad-return] - 1

```
 INFO Using config file explicitly provided at `pyre.toml`
ERROR badge.py:27:74-91: `dict[@_, @_]` is not assignable to `defaultdict[tuple[bool, bool, bool, bool, bool], list[str]]` [bad-assignment]
ERROR badge.py:28:70-87: `dict[@_, @_]` is not assignable to `defaultdict[tuple[bool, bool, bool, bool, bool], list[str]]` [bad-assignment]
ERROR badge.py:33:9-30: `+=` is not supported between `@17314` and `Literal[1]`
  TODO: Binding::AugAssign attribute base undefined for type: @_ (trying to access __add__) [internal-error]
ERROR badge.py:33:9-30: `+=` is not supported between `@17314` and `Literal[1]`
  TODO: Binding::AugAssign attribute base undefined for type: @_ (trying to access __iadd__) [internal-error]
ERROR badge.py:35:9-25: `+=` is not supported between `@17312` and `Literal[1]`
  TODO: Binding::AugAssign attribute base undefined for type: @_ (trying to access __add__) [internal-error]
ERROR badge.py:35:9-25: `+=` is not supported between `@17312` and `Literal[1]`
  TODO: Binding::AugAssign attribute base undefined for type: @_ (trying to access __iadd__) [internal-error]
ERROR coverage_sources\get_pyright_stats.py:102:17-41: Object of class `PurePath` has no attribute `iterdir` [missing-attribute]
ERROR coverage_sources\get_pyright_stats.py:105:12-20: Object of class `PurePath` has no attribute `is_dir` [missing-attribute]
ERROR analyzer\coverage_calculator.py:68:13-31: `+=` is not supported between `@3423` and `Literal[1]`
  TODO: Binding::AugAssign attribute base undefined for type: @_ (trying to access __add__) [internal-error]
ERROR analyzer\coverage_calculator.py:68:13-31: `+=` is not supported between `@3423` and `Literal[1]`
  TODO: Binding::AugAssign attribute base undefined for type: @_ (trying to access __iadd__) [internal-error]
ERROR analyzer\coverage_calculator.py:125:13-31: `+=` is not supported between `@3925` and `Literal[1]`
  TODO: Binding::AugAssign attribute base undefined for type: @_ (trying to access __add__) [internal-error]
ERROR analyzer\coverage_calculator.py:125:13-31: `+=` is not supported between `@3925` and `Literal[1]`
  TODO: Binding::AugAssign attribute base undefined for type: @_ (trying to access __iadd__) [internal-error]
ERROR main.py:231:17-45: Argument `(package_data: dict[str, Any], rank: int, typeshed_data: dict[str, dict[str, Any]], packages_with_stubs: set[str]) -> tuple[str, dict[str, Any]] | None` is not assignable to parameter with type `(*Unknown, **Unknown) -> tuple[str, dict[str, Any]] | None` in function `concurrent.futures._base.Executor.submit` [bad-argument-type]
ERROR main.py:243:17-45: Item assignment is not supported on `dict[str, Any] | @5306`
  TODO: Expr::call_method attribute base undefined for type: dict[str, Any] | @_ (trying to access __setitem__) [missing-attribute]
ERROR main.py:254:20-60: Returned type `list[bytes]` is not assignable to declared return type `list[str]` [bad-return]
ERROR main.py:378:23-26: Argument `type[int]` is not assignable to parameter `type` with type `((str) -> Any) | FileType | str` in function `argparse._ActionsContainer.add_argument` [bad-argument-type]
ERROR main.py:381:32-35: Argument `type[str]` is not assignable to parameter `type` with type `((str) -> Any) | FileType | str` in function `argparse._ActionsContainer.add_argument` [bad-argument-type]
ERROR main.py:401:32-35: Argument `type[str]` is not assignable to parameter `type` with type `((str) -> Any) | FileType | str` in function `argparse._ActionsContainer.add_argument` [bad-argument-type]
ERROR tests\test_main.py:48:23-42: No attribute `exceptions` in module `requests` [missing-attribute]
ERROR tests\test_get_pyright_stats.py:17:24-52: `PurePath` is not assignable to `Path` [bad-assignment]
ERROR tests\test_get_pyright_stats.py:44:27-90: `PurePath` is not assignable to `Path` [bad-assignment]
ERROR tests\test_get_pyright_stats.py:79:24-52: `PurePath` is not assignable to `Path` [bad-assignment]
ERROR tests\test_get_pyright_stats.py:80:23-61: `PurePath` is not assignable to `Path` [bad-assignment]
ERROR tests\test_get_pyright_stats.py:81:27-91: `PurePath` is not assignable to `Path` [bad-assignment]
ERROR tests\test_get_pyright_stats.py:82:25-64: `PurePath` is not assignable to `Path` [bad-assignment]
ERROR tests\test_package_analyzer.py:69:9-30: TODO: Answers::solve_binding_inner::CheckAssignExprToAttribute attribute base undefined for type: AsyncMock | MagicMock (trying to access return_value) [internal-error]      
ERROR tests\test_package_analyzer.py:85:9-30: TODO: Answers::solve_binding_inner::CheckAssignExprToAttribute attribute base undefined for type: AsyncMock | MagicMock (trying to access return_value) [internal-error]      
ERROR analyzer\historical_view_generator.py:22:25-49: Item assignment is not supported on `@4940 | @4941`
  TODO: Expr::call_method attribute base undefined for type: @_ | @_ (trying to access __setitem__) [missing-attribute]
ERROR analyzer\historical_view_generator.py:28:21-45: Can't apply arguments to non-class, got dict[str, list[dict[str, Any]]] [bad-specialization]
ERROR analyzer\package_analyzer.py:51:8-26: Object of class `NoneType` has no attribute `endswith` [missing-attribute]
ERROR analyzer\package_analyzer.py:57:10-28: Object of class `NoneType` has no attribute `endswith` [missing-attribute]
ERROR tests\test_typeshed_checker.py:16:5-22: Object of class `PurePath` has no attribute `mkdir` [missing-attribute]
ERROR tests\test_typeshed_checker.py:17:5-46: Object of class `PurePath` has no attribute `write_text` [missing-attribute]
ERROR tests\test_typeshed_checker.py:18:5-44: Object of class `PurePath` has no attribute `write_text` [missing-attribute]
ERROR tests\test_typeshed_checker.py:93:5-22: Object of class `PurePath` has no attribute `mkdir` [missing-attribute]
ERROR tests\test_typeshed_checker.py:96:5-25: Object of class `PurePath` has no attribute `write_text` [missing-attribute]
ERROR tests\test_typeshed_checker.py:99:5-27: Object of class `PurePath` has no attribute `write_text` [missing-attribute]
ERROR tests\test_typeshed_checker.py:102:5-26: Object of class `PurePath` has no attribute `write_text` [missing-attribute]
 INFO 38 errors (0 suppressed), 442 modules, 135,663 lines, took 117.20ms (113.27ms without printing errors), peak memory physical 85.1 Mi
```