### PR TITLE
Reduce blue tint in coverage gradient

### DIFF
--- a/analyzer/report_generator.py
+++ b/analyzer/report_generator.py
@@ -145,7 +145,7 @@ def get_color(percentage: float) -> str:
         red = int(255 * ((100 - percentage) / 50))
         green = 255
 
-    blue = 200  # A small amount of blue for a softer, more pleasant color
+    blue = 55  # A small amount of blue for a softer, more pleasant color
     return f"rgb({red},{green},{blue})"
 
 


### PR DESCRIPTION
## Summary
- use subtle blue value 55 in coverage color gradient to avoid magenta hues

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6611fc668832a8aa3c9fac8dff4ee