### PR TITLE
Add check_untyped_defs to mypy benchmark config for fair comparison

### DIFF
--- a/typecheck_benchmark/daily_runner.py
+++ b/typecheck_benchmark/daily_runner.py
@@ -554,6 +554,8 @@ def _write_dummy_mypy_config(
         f.write("[mypy]\n")
         if check_paths:
             f.write(f"files = {', '.join(check_paths)}\n")
+        # Check bodies of untyped functions (other checkers do this by default)
+        f.write("check_untyped_defs = True\n")
         # Exclude test dirs to avoid duplicate module / syntax errors
         # that cause mypy to bail out without checking anything
         f.write("exclude = (?x)(\n    /tests/\n    | /test_\n    | /testing/\n  )\n")

--- a/typecheck_benchmark/index.html
+++ b/typecheck_benchmark/index.html
@@ -211,7 +211,7 @@
                     </p>
                     <ul>
                         <li><strong>Pyright:</strong> <code>pyrightconfig.json</code> with <code>"include": [paths]</code> written in-place</li>
-                        <li><strong>Mypy:</strong> <code>[mypy]</code> with <code>files = paths</code> via <code>--config-file</code></li>
+                        <li><strong>Mypy:</strong> <code>[mypy]</code> with <code>files = paths</code> and <code>check_untyped_defs = True</code> via <code>--config-file</code></li>
                         <li><strong>ty:</strong> <code>[src] include = [paths]</code> in <code>ty.benchmark.toml</code> via <code>--config-file</code></li>
                         <li><strong>Pyrefly:</strong> <code>project_includes = [paths]</code> in <code>pyrefly.benchmark.toml</code> via <code>--config</code></li>
                         <li><strong>Zuban:</strong> <code>[mypy]</code> with <code>files = paths</code> via <code>--config-file</code></li>
@@ -219,6 +219,13 @@
                     <p class="method-note">
                         This means every checker sees exactly the same target paths and
                         a neutral configuration, regardless of what the package ships.
+                    </p>
+                    <p class="method-note">
+                        <strong>Mypy note:</strong> By default, mypy skips the bodies of
+                        functions that lack type annotations. The other four checkers all
+                        analyze unannotated code. We enable <code>check_untyped_defs = True</code>
+                        so that mypy checks the same amount of code as the other tools,
+                        making the comparison fair.
                     </p>
                 </div>
                 <div class="method-card">


### PR DESCRIPTION
Other type checkers check untyped function bodies by default. Without this flag, mypy silently skips them, giving it an unfair speed advantage.