### PR TITLE
Add --repo-cache flag to persist cloned repos between benchmark runs

### DIFF
--- a/lsp/benchmark/daily_runner.py
+++ b/lsp/benchmark/daily_runner.py
@@ -263,6 +263,9 @@ def fetch_github_package(
 ) -> Path | None:
     """Clone a GitHub repository for benchmarking.
 
+    If *temp_dir/package_name* already exists (e.g. from a previous run with
+    ``--repo-cache``), the existing checkout is reused.
+
     Args:
         github_url: URL of the GitHub repository.
         package_name: Name to use for the cloned directory.
@@ -273,6 +276,10 @@ def fetch_github_package(
         Path to the cloned repository, or None on failure.
     """
     target_path = temp_dir / package_name
+
+    if target_path.exists():
+        print(f"  Reusing cached clone at {target_path}")
+        return target_path
 
     try:
         print(f"  Cloning {github_url}...")
@@ -632,6 +639,7 @@ def run_daily_benchmark(
     seed: int | None = None,
     os_name: str | None = None,
     warmup_s: float = 0.0,
+    repo_cache: Path | None = None,
 ) -> Path:
     """Run the daily benchmark suite.
 
@@ -643,6 +651,9 @@ def run_daily_benchmark(
         output_dir: Directory to write results to.
         seed: Random seed for reproducibility.
         os_name: OS name to include in output filename (e.g., ubuntu, macos, windows).
+        warmup_s: Seconds to wait after initialization.
+        repo_cache: Persistent directory for cloned repos. When set, repos
+            are kept between runs, skipping re-clone.
 
     Returns:
         Path to the output JSON file.
@@ -673,7 +684,10 @@ def run_daily_benchmark(
         print(f"  {name}: {version}")
     print()
 
-    all_results = _run_all_benchmarks(packages, type_checkers, runs_per_package, seed, warmup_s=warmup_s)
+    all_results = _run_all_benchmarks(
+        packages, type_checkers, runs_per_package, seed,
+        warmup_s=warmup_s, repo_cache=repo_cache,
+    )
 
     # Compute aggregate statistics
     aggregate_stats = compute_aggregate_stats(all_results, type_checkers)
@@ -721,6 +735,7 @@ def _run_all_benchmarks(
     runs_per_package: int,
     seed: int | None,
     warmup_s: float = 0.0,
+    repo_cache: Path | None = None,
 ) -> list[PackageResult]:
     """Run benchmarks for all packages.
 
@@ -731,26 +746,38 @@ def _run_all_benchmarks(
         seed: Random seed for reproducibility.
         warmup_s: Seconds to wait after opening a document before sending
                   the definition request.
+        repo_cache: If provided, clones are stored in this persistent
+            directory and reused across runs.
 
     Returns:
         List of package results.
     """
     all_results: list[PackageResult] = []
 
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_path = Path(temp_dir)
-
+    if repo_cache:
+        repo_cache.mkdir(parents=True, exist_ok=True)
+        print(f"Using repo cache: {repo_cache}")
         for i, package in enumerate(packages, 1):
             package_name = package["name"]
             github_url = package.get("github_url")
-
             print(f"\n[{i}/{len(packages)}] Processing {package_name}")
-
             result = _benchmark_single_package(
-                package, github_url, temp_path, type_checkers, runs_per_package, seed,
-                warmup_s=warmup_s,
+                package, github_url, repo_cache, type_checkers,
+                runs_per_package, seed, warmup_s=warmup_s, persistent=True,
             )
             all_results.append(result)
+    else:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            for i, package in enumerate(packages, 1):
+                package_name = package["name"]
+                github_url = package.get("github_url")
+                print(f"\n[{i}/{len(packages)}] Processing {package_name}")
+                result = _benchmark_single_package(
+                    package, github_url, temp_path, type_checkers,
+                    runs_per_package, seed, warmup_s=warmup_s,
+                )
+                all_results.append(result)
 
     return all_results
 
@@ -763,6 +790,7 @@ def _benchmark_single_package(
     runs_per_package: int,
     seed: int | None,
     warmup_s: float = 0.0,
+    persistent: bool = False,
 ) -> PackageResult:
     """Benchmark a single package.
 
@@ -775,6 +803,8 @@ def _benchmark_single_package(
         seed: Random seed for reproducibility.
         warmup_s: Seconds to wait after opening a document before sending
                   the definition request.
+        persistent: When True (repo-cache mode), the cloned repo is kept
+            on disk for reuse in later runs.
 
     Returns:
         Package result dictionary.
@@ -830,8 +860,9 @@ def _benchmark_single_package(
             "metrics": {},
         }
     finally:
-        # Cleanup package directory
-        shutil.rmtree(package_path, ignore_errors=True)
+        # Cleanup package directory (skip in repo-cache mode)
+        if not persistent:
+            shutil.rmtree(package_path, ignore_errors=True)
 
 
 def _save_results(
@@ -964,6 +995,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Seconds to wait after initialization before sending definition "
         "requests. Gives the server time to index/analyze (default: 30).",
     )
+    parser.add_argument(
+        "--repo-cache",
+        type=Path,
+        default=None,
+        help="Persistent directory for cloned repos. Repos are kept between "
+        "runs, skipping re-clone.",
+    )
 
     return parser.parse_args(argv)
 
@@ -988,6 +1026,7 @@ def main(argv: list[str] | None = None) -> int:
         seed=args.seed,
         os_name=args.os_name,
         warmup_s=args.warmup,
+        repo_cache=args.repo_cache,
     )
 
     return 0

--- a/typecheck_benchmark/daily_runner.py
+++ b/typecheck_benchmark/daily_runner.py
@@ -436,8 +436,15 @@ def clone_package(
     dest: Path,
     timeout: int = 180,
 ) -> Path | None:
-    """Shallow-clone a GitHub repository."""
+    """Shallow-clone a GitHub repository.
+
+    If *dest/name* already exists (e.g. from a previous run with
+    ``--repo-cache``), the existing checkout is reused.
+    """
     target = dest / name
+    if target.exists():
+        print(f"  Reusing cached clone at {target}")
+        return target
     try:
         print(f"  Cloning {github_url}...")
         result = subprocess.run(
@@ -459,7 +466,16 @@ def clone_package(
 
 
 def install_deps(package_path: Path, env_config: dict[str, Any]) -> bool:
-    """Install dependencies for a package."""
+    """Install dependencies for a package.
+
+    When a repo-cache directory is used, a ``.deps_installed`` marker file is
+    written after a successful install so subsequent runs skip the step.
+    """
+    marker = package_path / ".deps_installed"
+    if marker.exists():
+        print("  Dependencies already installed (cached)")
+        return True
+
     install_self = env_config.get("install", False)
     deps = env_config.get("deps", [])
     install_env = env_config.get("install_env", {})
@@ -501,6 +517,8 @@ def install_deps(package_path: Path, env_config: dict[str, Any]) -> bool:
             print(f"  Warning: pip install deps timed out")
             return False
 
+    # Mark deps as installed so cached clones skip this step next time.
+    marker.touch()
     return True
 
 
@@ -790,6 +808,7 @@ def run_benchmark(
     os_name: str | None = None,
     install_envs_file: Path | None = None,
     runs: int = 1,
+    repo_cache: Path | None = None,
 ) -> Path:
     """Run the full benchmark suite.
 
@@ -802,6 +821,8 @@ def run_benchmark(
         os_name: OS name for filename (ubuntu, macos, windows).
         install_envs_file: Path to install_envs.json.
         runs: Number of runs per checker per package.
+        repo_cache: Persistent directory for cloned repos. When set, repos
+            and their installed deps are kept between runs.
 
     Returns:
         Path to the dated output JSON file.
@@ -846,7 +867,7 @@ def run_benchmark(
     print()
 
     # Run benchmarks
-    all_results = _run_all(packages, type_checkers, timeout, runs)
+    all_results = _run_all(packages, type_checkers, timeout, runs, repo_cache=repo_cache)
 
     # Aggregate
     aggregate = compute_aggregate_stats(all_results, type_checkers)
@@ -872,21 +893,34 @@ def _run_all(
     type_checkers: list[str],
     timeout: int,
     runs: int = 1,
+    repo_cache: Path | None = None,
 ) -> list[PackageResult]:
-    """Run benchmarks for all packages."""
+    """Run benchmarks for all packages.
+
+    Args:
+        repo_cache: If provided, clones are stored in this persistent
+            directory and reused across runs instead of a temporary directory.
+    """
     all_results: list[PackageResult] = []
 
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_path = Path(temp_dir)
-
+    if repo_cache:
+        repo_cache.mkdir(parents=True, exist_ok=True)
+        print(f"Using repo cache: {repo_cache}")
         for i, pkg in enumerate(packages, 1):
-            name = pkg["name"]
-            github_url = pkg.get("github_url", "")
-
-            print(f"\n[{i}/{len(packages)}] {name}")
-
-            result = _benchmark_package(pkg, temp_path, type_checkers, timeout, runs)
+            print(f"\n[{i}/{len(packages)}] {pkg['name']}")
+            result = _benchmark_package(
+                pkg, repo_cache, type_checkers, timeout, runs, persistent=True,
+            )
             all_results.append(result)
+    else:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            for i, pkg in enumerate(packages, 1):
+                print(f"\n[{i}/{len(packages)}] {pkg['name']}")
+                result = _benchmark_package(
+                    pkg, temp_path, type_checkers, timeout, runs,
+                )
+                all_results.append(result)
 
     return all_results
 
@@ -897,8 +931,14 @@ def _benchmark_package(
     type_checkers: list[str],
     timeout: int,
     runs: int = 1,
+    persistent: bool = False,
 ) -> PackageResult:
-    """Benchmark a single package: clone, install deps, run checkers."""
+    """Benchmark a single package: clone, install deps, run checkers.
+
+    Args:
+        persistent: When True (repo-cache mode), the cloned repo and
+            installed deps are kept on disk for reuse in later runs.
+    """
     name = pkg["name"]
     github_url = pkg.get("github_url", "")
 
@@ -1001,8 +1041,9 @@ def _benchmark_package(
             else:
                 print(f"      {result_metric['execution_time_s']:.1f}s{mem_str}")
 
-    # Cleanup cloned repo
-    shutil.rmtree(package_path, ignore_errors=True)
+    # Cleanup cloned repo (skip in repo-cache mode)
+    if not persistent:
+        shutil.rmtree(package_path, ignore_errors=True)
 
     return {
         "package_name": name,
@@ -1123,6 +1164,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--runs", "-r", type=int, default=1,
         help="Number of runs per checker per package (default: 1)",
     )
+    parser.add_argument(
+        "--repo-cache", type=Path, default=None,
+        help="Persistent directory for cloned repos. Repos and installed deps "
+        "are kept between runs, skipping re-clone and re-install.",
+    )
     return parser.parse_args(argv)
 
 
@@ -1138,6 +1184,7 @@ def main(argv: list[str] | None = None) -> int:
         os_name=args.os_name,
         install_envs_file=args.install_envs,
         runs=args.runs,
+        repo_cache=args.repo_cache,
     )
     return 0
 


### PR DESCRIPTION
Adds a --repo-cache option to both the typecheck and LSP benchmarks that stores cloned repos in a persistent directory. On subsequent runs, repos are reused and dependency installation is skipped, saving significant time for local iterative benchmarking.