### PR TITLE
Fix zuban LSP command: zubanls no longer exists, use zuban server

### DIFF
--- a/.github/workflows/lsp-benchmark-pr.yml
+++ b/.github/workflows/lsp-benchmark-pr.yml
@@ -46,7 +46,7 @@ jobs:
           which pyright-langserver && echo "  pyright: $(pyright --version)" || echo "  pyright: not found"
           which pyrefly && echo "  pyrefly: installed" || echo "  pyrefly: not found"
           which ty && echo "  ty: installed" || echo "  ty: not found"
-          which zubanls && echo "  zuban: installed" || echo "  zuban: not found"
+          which zuban && echo "  zuban: installed" || echo "  zuban: not found"
 
       - name: Run LSP Benchmark (smoke test)
         shell: bash

--- a/.github/workflows/lsp-benchmark.yml
+++ b/.github/workflows/lsp-benchmark.yml
@@ -76,7 +76,7 @@ jobs:
           which pyright-langserver && echo "  pyright: $(pyright --version)" || echo "  pyright: not found"
           which pyrefly && echo "  pyrefly: installed" || echo "  pyrefly: not found"
           which ty && echo "  ty: installed" || echo "  ty: not found"
-          which zubanls && echo "  zuban: installed" || echo "  zuban: not found"
+          which zuban && echo "  zuban: installed" || echo "  zuban: not found"
 
       - name: Fetch accumulated results from published-report
         shell: bash

--- a/lsp/benchmark/daily_runner.py
+++ b/lsp/benchmark/daily_runner.py
@@ -182,7 +182,7 @@ TYPE_CHECKER_COMMANDS: dict[str, str] = {
     "pyright": "pyright-langserver --stdio",
     "pyrefly": "pyrefly lsp",
     "ty": "ty server",
-    "zuban": "zubanls",
+    "zuban": "zuban server",
 }
 
 DEFAULT_TYPE_CHECKERS: list[str] = ["pyright", "pyrefly", "ty", "zuban"]


### PR DESCRIPTION
The zuban package changed its binary layout — it no longer ships a separate `zubanls` executable. The LSP is now started via `zuban server`, similar to how ty uses `ty server`.