### PR TITLE
Change typecheck benchmark default to 5 runs per package and warmup

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Runs daily at 10 AM EST. Analyzes a curated list of packages (defined in `includ
 Runs daily at 3 AM UTC on Ubuntu and Windows, weekly on Tuesdays for macOS. Benchmarks LSP performance (time-to-first-diagnostic, completions, hover) across Pyright, Pyrefly, ty, and Zuban on the prioritized package list. Each OS produces a separate results JSON. Deploys to `published-report` with retry logic for concurrent matrix job pushes.
 
 ### Daily Type Checker Timing Benchmark (`typecheck-benchmark.yml`)
-Runs daily at 5 AM UTC on Ubuntu and Windows, weekly on Wednesdays for macOS. Measures full type-checking time across Pyright, Pyrefly, ty, mypy, and Zuban on packages with install configurations. Each OS produces a separate results JSON. Deploys to `published-report` with retry logic for concurrent matrix job pushes.
+Runs daily at 5 AM UTC on Ubuntu and Windows, weekly on Wednesdays for macOS. Measures full type-checking time across Pyright, Pyrefly, ty, mypy, and Zuban on packages with install configurations. Each checker is run 5 times per package and results are averaged. Each OS produces a separate results JSON. Deploys to `published-report` with retry logic for concurrent matrix job pushes.
 
 ## Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
         "pyright": "^1.1.378"
       },
       "devDependencies": {
-        "typescript": "^5.7"
+        "typescript": "^5.9.3"
       }
     },
     "node_modules/fsevents": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,6 @@
     "pyright": "^1.1.378"
   },
   "devDependencies": {
-    "typescript": "^5.7"
+    "typescript": "^5.9.3"
   }
 }

--- a/typecheck_benchmark/daily_runner.py
+++ b/typecheck_benchmark/daily_runner.py
@@ -793,6 +793,7 @@ def run_benchmark(
     install_envs_file: Path | None = None,
     runs: int = 1,
     local_dir: Path | None = None,
+    warmup: int = 1,
 ) -> Path:
     """Run the full benchmark suite.
 
@@ -806,6 +807,7 @@ def run_benchmark(
         install_envs_file: Path to install_envs.json.
         runs: Number of runs per checker per package.
         local_dir: Path to a local directory to benchmark directly.
+        warmup: Number of warmup runs to discard before measured runs.
 
     Returns:
         Path to the dated output JSON file.
@@ -819,6 +821,7 @@ def run_benchmark(
     if local_dir is not None:
         return _run_local_benchmark(
             local_dir, type_checkers, timeout, output_dir, os_name, runs,
+            warmup,
         )
 
     # Load packages
@@ -844,6 +847,7 @@ def run_benchmark(
     print(f"Type checkers: {', '.join(type_checkers)}")
     print(f"Timeout: {timeout}s per checker")
     print(f"Runs per checker: {runs}")
+    print(f"Warmup runs: {warmup}")
     print("=" * 70)
 
     # Versions
@@ -855,7 +859,7 @@ def run_benchmark(
     print()
 
     # Run benchmarks
-    all_results = _run_all(packages, type_checkers, timeout, runs)
+    all_results = _run_all(packages, type_checkers, timeout, runs, warmup)
 
     # Aggregate
     aggregate = compute_aggregate_stats(all_results, type_checkers)
@@ -863,7 +867,7 @@ def run_benchmark(
     # Save
     output_file = _save_results(
         all_results, aggregate, type_checkers, versions, len(packages),
-        output_dir, os_name, runs,
+        output_dir, os_name, runs, warmup,
     )
 
     # Print summary
@@ -883,6 +887,7 @@ def _run_local_benchmark(
     output_dir: Path,
     os_name: str | None,
     runs: int,
+    warmup: int = 1,
 ) -> Path:
     """Run benchmark against a local directory (no clone/install)."""
     local_dir = local_dir.resolve()
@@ -900,6 +905,7 @@ def _run_local_benchmark(
     print(f"Type checkers: {', '.join(type_checkers)}")
     print(f"Timeout: {timeout}s per checker")
     print(f"Runs per checker: {runs}")
+    print(f"Warmup runs: {warmup}")
     print("=" * 70)
 
     # Versions
@@ -912,7 +918,7 @@ def _run_local_benchmark(
 
     # Run checkers
     print(f"\n[1/1] {name} (local)")
-    result = _benchmark_local_dir(local_dir, type_checkers, timeout, runs)
+    result = _benchmark_local_dir(local_dir, type_checkers, timeout, runs, warmup)
     all_results = [result]
 
     # Aggregate
@@ -921,7 +927,7 @@ def _run_local_benchmark(
     # Save
     output_file = _save_results(
         all_results, aggregate, type_checkers, versions, 1,
-        output_dir, os_name, runs,
+        output_dir, os_name, runs, warmup,
     )
 
     # Print summary
@@ -939,6 +945,7 @@ def _benchmark_local_dir(
     type_checkers: list[str],
     timeout: int,
     runs: int = 1,
+    warmup: int = 1,
 ) -> PackageResult:
     """Benchmark a local directory: run checkers without clone/install."""
     name = local_dir.name
@@ -955,32 +962,36 @@ def _benchmark_local_dir(
             }
             continue
 
-        print(f"    Running {checker}... ({runs} run{'s' if runs > 1 else ''})")
+        total = warmup + runs
+        print(f"    Running {checker}... ({warmup} warmup + {runs} run{'s' if runs > 1 else ''})")
         times: list[float] = []
         memories: list[float] = []
         failed_metric: TimingMetrics | None = None
 
-        for run_idx in range(runs):
-            if runs > 1:
-                print(f"      Run {run_idx + 1}/{runs}...", end=" ")
+        for run_idx in range(total):
+            is_warmup = run_idx < warmup
+            if is_warmup:
+                label = f"Warmup {run_idx + 1}/{warmup}"
+            else:
+                label = f"Run {run_idx - warmup + 1}/{runs}"
+            print(f"      {label}...", end=" ")
             m = run_checker(checker, local_dir, None, timeout)
             if not m.get("ok"):
-                if runs > 1:
-                    print(f"Failed: {m.get('error_message', 'Unknown')}")
+                print(f"Failed: {m.get('error_message', 'Unknown')}")
                 failed_metric = m
                 break
-            times.append(m["execution_time_s"])
-            memories.append(m.get("peak_memory_mb", 0.0))
-            if runs > 1:
-                peak = m.get("peak_memory_mb", 0)
-                mem_str = f", {peak:.0f}MB" if peak > 0 else ""
+            peak = m.get("peak_memory_mb", 0)
+            mem_str = f", {peak:.0f}MB" if peak > 0 else ""
+            if is_warmup:
+                print(f"{m['execution_time_s']:.1f}s{mem_str} (discarded)")
+            else:
+                times.append(m["execution_time_s"])
+                memories.append(m.get("peak_memory_mb", 0.0))
                 print(f"{m['execution_time_s']:.1f}s{mem_str}")
 
         if failed_metric is not None:
             failed_metric["runs"] = len(times) + 1
             metrics[checker] = failed_metric
-            if runs == 1:
-                print(f"      Failed: {failed_metric.get('error_message', 'Unknown')}")
         else:
             result_metric: TimingMetrics = {
                 "ok": True,
@@ -1017,6 +1028,7 @@ def _run_all(
     type_checkers: list[str],
     timeout: int,
     runs: int = 1,
+    warmup: int = 1,
 ) -> list[PackageResult]:
     """Run benchmarks for all packages."""
     all_results: list[PackageResult] = []
@@ -1030,7 +1042,9 @@ def _run_all(
 
             print(f"\n[{i}/{len(packages)}] {name}")
 
-            result = _benchmark_package(pkg, temp_path, type_checkers, timeout, runs)
+            result = _benchmark_package(
+                pkg, temp_path, type_checkers, timeout, runs, warmup,
+            )
             all_results.append(result)
 
     return all_results
@@ -1042,6 +1056,7 @@ def _benchmark_package(
     type_checkers: list[str],
     timeout: int,
     runs: int = 1,
+    warmup: int = 1,
 ) -> PackageResult:
     """Benchmark a single package: clone, install deps, run checkers."""
     name = pkg["name"]
@@ -1097,32 +1112,36 @@ def _benchmark_package(
             }
             continue
 
-        print(f"    Running {checker}... ({runs} run{'s' if runs > 1 else ''})")
+        total = warmup + runs
+        print(f"    Running {checker}... ({warmup} warmup + {runs} run{'s' if runs > 1 else ''})")
         times: list[float] = []
         memories: list[float] = []
         failed_metric: TimingMetrics | None = None
 
-        for run_idx in range(runs):
-            if runs > 1:
-                print(f"      Run {run_idx + 1}/{runs}...", end=" ")
+        for run_idx in range(total):
+            is_warmup = run_idx < warmup
+            if is_warmup:
+                label = f"Warmup {run_idx + 1}/{warmup}"
+            else:
+                label = f"Run {run_idx - warmup + 1}/{runs}"
+            print(f"      {label}...", end=" ")
             m = run_checker(checker, package_path, resolved_paths, timeout)
             if not m.get("ok"):
-                if runs > 1:
-                    print(f"Failed: {m.get('error_message', 'Unknown')}")
+                print(f"Failed: {m.get('error_message', 'Unknown')}")
                 failed_metric = m
                 break
-            times.append(m["execution_time_s"])
-            memories.append(m.get("peak_memory_mb", 0.0))
-            if runs > 1:
-                peak = m.get("peak_memory_mb", 0)
-                mem_str = f", {peak:.0f}MB" if peak > 0 else ""
+            peak = m.get("peak_memory_mb", 0)
+            mem_str = f", {peak:.0f}MB" if peak > 0 else ""
+            if is_warmup:
+                print(f"{m['execution_time_s']:.1f}s{mem_str} (discarded)")
+            else:
+                times.append(m["execution_time_s"])
+                memories.append(m.get("peak_memory_mb", 0.0))
                 print(f"{m['execution_time_s']:.1f}s{mem_str}")
 
         if failed_metric is not None:
             failed_metric["runs"] = len(times) + 1
             metrics[checker] = failed_metric
-            if runs == 1:
-                print(f"      Failed: {failed_metric.get('error_message', 'Unknown')}")
         else:
             result_metric: TimingMetrics = {
                 "ok": True,
@@ -1166,6 +1185,7 @@ def _save_results(
     output_dir: Path,
     os_name: str | None = None,
     runs: int = 1,
+    warmup: int = 1,
 ) -> Path:
     """Save benchmark results to JSON."""
     timestamp = datetime.now(timezone.utc)
@@ -1185,6 +1205,7 @@ def _save_results(
         "type_checker_versions": {k: v for k, v in versions.items() if k in type_checkers},
         "package_count": package_count,
         "runs_per_package": runs,
+        "warmup_runs": warmup,
         "aggregate": aggregate,
         "results": results,
     }
@@ -1269,6 +1290,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Number of runs per checker per package (default: 5)",
     )
     parser.add_argument(
+        "--warmup", "-w", type=int, default=1,
+        help="Number of warmup runs to discard before measured runs (default: 1)",
+    )
+    parser.add_argument(
         "--local", type=Path, default=None,
         help="Path to a local directory to benchmark instead of cloning from GitHub",
     )
@@ -1288,6 +1313,7 @@ def main(argv: list[str] | None = None) -> int:
         install_envs_file=args.install_envs,
         runs=args.runs,
         local_dir=args.local,
+        warmup=args.warmup,
     )
     return 0
 

--- a/typecheck_benchmark/daily_runner.py
+++ b/typecheck_benchmark/daily_runner.py
@@ -1265,8 +1265,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Path to install_envs.json (default: typecheck_benchmark/install_envs.json)",
     )
     parser.add_argument(
-        "--runs", "-r", type=int, default=1,
-        help="Number of runs per checker per package (default: 1)",
+        "--runs", "-r", type=int, default=5,
+        help="Number of runs per checker per package (default: 5)",
     )
     parser.add_argument(
         "--local", type=Path, default=None,

--- a/typecheck_benchmark/index.html
+++ b/typecheck_benchmark/index.html
@@ -167,8 +167,8 @@
                     <ol>
                         <li>Shallow-clone each package from GitHub</li>
                         <li>Install package dependencies per <code>install_envs.json</code></li>
-                        <li>Run each type checker with a 5-minute timeout</li>
-                        <li>Record wall-clock time and peak memory usage</li>
+                        <li>Run each type checker 5 times with a 5-minute timeout per run</li>
+                        <li>Record wall-clock time and peak memory usage (mean of 5 runs)</li>
                     </ol>
                     <p class="method-note">
                         <strong>Timeout:</strong> Each type checker has a 5-minute timeout.

--- a/typecheck_benchmark/index.html
+++ b/typecheck_benchmark/index.html
@@ -167,8 +167,8 @@
                     <ol>
                         <li>Shallow-clone each package from GitHub</li>
                         <li>Install package dependencies per <code>install_envs.json</code></li>
-                        <li>Run each type checker 5 times with a 5-minute timeout per run</li>
-                        <li>Record wall-clock time and peak memory usage (mean of 5 runs)</li>
+                        <li>Run each type checker with 1 warmup run (discarded) + 5 measured runs, with a 5-minute timeout per run</li>
+                        <li>Record wall-clock time and peak memory usage (mean of 5 measured runs)</li>
                     </ol>
                     <p class="method-note">
                         <strong>Timeout:</strong> Each type checker has a 5-minute timeout.

--- a/typecheck_benchmark/scripts/typecheck-benchmark.js
+++ b/typecheck_benchmark/scripts/typecheck-benchmark.js
@@ -89,6 +89,7 @@ function getDemoData() {
         type_checker_versions: { pyright: '1.1.408', pyrefly: '0.54.0', ty: '0.0.19', mypy: '1.19.1', zuban: '0.6.1' },
         package_count: 5,
         runs_per_package: 5,
+        warmup_runs: 1,
         aggregate: {
             pyright: { packages_tested: 5, packages_failed: 0, avg_execution_time_s: 12.5, p90_execution_time_s: 22.0, p95_execution_time_s: 25.0, max_execution_time_s: 30.0, total_execution_time_s: 62.5, avg_peak_memory_mb: 350, p90_peak_memory_mb: 480, p95_peak_memory_mb: 500, max_peak_memory_mb: 550 },
             pyrefly: { packages_tested: 5, packages_failed: 0, avg_execution_time_s: 3.2, p90_execution_time_s: 5.5, p95_execution_time_s: 6.0, max_execution_time_s: 8.0, total_execution_time_s: 16.0, avg_peak_memory_mb: 280, p90_peak_memory_mb: 380, p95_peak_memory_mb: 400, max_peak_memory_mb: 420 },
@@ -223,8 +224,10 @@ function updateTimestamp() {
     if (benchmarkData?.timestamp) {
         const d = new Date(benchmarkData.timestamp);
         const runs = benchmarkData.runs_per_package;
+        const warmup = benchmarkData.warmup_runs;
         const runsStr = runs && runs > 1 ? ` | ${runs} runs per package` : '';
-        el.textContent = `Last updated: ${d.toLocaleDateString()} at ${d.toLocaleTimeString()}${runsStr}`;
+        const warmupStr = warmup && warmup > 0 ? ` (${warmup} warmup)` : '';
+        el.textContent = `Last updated: ${d.toLocaleDateString()} at ${d.toLocaleTimeString()}${runsStr}${warmupStr}`;
     }
     else {
         el.textContent = 'Demo data';

--- a/typecheck_benchmark/scripts/typecheck-benchmark.js
+++ b/typecheck_benchmark/scripts/typecheck-benchmark.js
@@ -88,6 +88,7 @@ function getDemoData() {
         type_checkers: ['pyright', 'pyrefly', 'ty', 'mypy', 'zuban'],
         type_checker_versions: { pyright: '1.1.408', pyrefly: '0.54.0', ty: '0.0.19', mypy: '1.19.1', zuban: '0.6.1' },
         package_count: 5,
+        runs_per_package: 5,
         aggregate: {
             pyright: { packages_tested: 5, packages_failed: 0, avg_execution_time_s: 12.5, p90_execution_time_s: 22.0, p95_execution_time_s: 25.0, max_execution_time_s: 30.0, total_execution_time_s: 62.5, avg_peak_memory_mb: 350, p90_peak_memory_mb: 480, p95_peak_memory_mb: 500, max_peak_memory_mb: 550 },
             pyrefly: { packages_tested: 5, packages_failed: 0, avg_execution_time_s: 3.2, p90_execution_time_s: 5.5, p95_execution_time_s: 6.0, max_execution_time_s: 8.0, total_execution_time_s: 16.0, avg_peak_memory_mb: 280, p90_peak_memory_mb: 380, p95_peak_memory_mb: 400, max_peak_memory_mb: 420 },
@@ -221,7 +222,9 @@ function updateTimestamp() {
         return;
     if (benchmarkData?.timestamp) {
         const d = new Date(benchmarkData.timestamp);
-        el.textContent = `Last updated: ${d.toLocaleDateString()} at ${d.toLocaleTimeString()}`;
+        const runs = benchmarkData.runs_per_package;
+        const runsStr = runs && runs > 1 ? ` | ${runs} runs per package` : '';
+        el.textContent = `Last updated: ${d.toLocaleDateString()} at ${d.toLocaleTimeString()}${runsStr}`;
     }
     else {
         el.textContent = 'Demo data';

--- a/typecheck_benchmark/scripts/typecheck-benchmark.ts
+++ b/typecheck_benchmark/scripts/typecheck-benchmark.ts
@@ -44,6 +44,7 @@ interface TimingBenchmarkData {
     type_checkers: string[];
     type_checker_versions?: Record<string, string>;
     package_count: number;
+    runs_per_package?: number;
     aggregate: Record<string, TimingAggregateEntry>;
     results: TimingBenchmarkResult[];
 }
@@ -146,6 +147,7 @@ function getDemoData(): TimingBenchmarkData {
         type_checkers: ['pyright', 'pyrefly', 'ty', 'mypy', 'zuban'],
         type_checker_versions: { pyright: '1.1.408', pyrefly: '0.54.0', ty: '0.0.19', mypy: '1.19.1', zuban: '0.6.1' },
         package_count: 5,
+        runs_per_package: 5,
         aggregate: {
             pyright:  { packages_tested: 5, packages_failed: 0, avg_execution_time_s: 12.5, p90_execution_time_s: 22.0, p95_execution_time_s: 25.0, max_execution_time_s: 30.0, total_execution_time_s: 62.5, avg_peak_memory_mb: 350, p90_peak_memory_mb: 480, p95_peak_memory_mb: 500, max_peak_memory_mb: 550 },
             pyrefly:  { packages_tested: 5, packages_failed: 0, avg_execution_time_s: 3.2, p90_execution_time_s: 5.5, p95_execution_time_s: 6.0, max_execution_time_s: 8.0, total_execution_time_s: 16.0, avg_peak_memory_mb: 280, p90_peak_memory_mb: 380, p95_peak_memory_mb: 400, max_peak_memory_mb: 420 },
@@ -285,7 +287,9 @@ function updateTimestamp(): void {
     if (!el) return;
     if (benchmarkData?.timestamp) {
         const d = new Date(benchmarkData.timestamp);
-        el.textContent = `Last updated: ${d.toLocaleDateString()} at ${d.toLocaleTimeString()}`;
+        const runs = benchmarkData.runs_per_package;
+        const runsStr = runs && runs > 1 ? ` | ${runs} runs per package` : '';
+        el.textContent = `Last updated: ${d.toLocaleDateString()} at ${d.toLocaleTimeString()}${runsStr}`;
     } else {
         el.textContent = 'Demo data';
     }

--- a/typecheck_benchmark/scripts/typecheck-benchmark.ts
+++ b/typecheck_benchmark/scripts/typecheck-benchmark.ts
@@ -45,6 +45,7 @@ interface TimingBenchmarkData {
     type_checker_versions?: Record<string, string>;
     package_count: number;
     runs_per_package?: number;
+    warmup_runs?: number;
     aggregate: Record<string, TimingAggregateEntry>;
     results: TimingBenchmarkResult[];
 }
@@ -148,6 +149,7 @@ function getDemoData(): TimingBenchmarkData {
         type_checker_versions: { pyright: '1.1.408', pyrefly: '0.54.0', ty: '0.0.19', mypy: '1.19.1', zuban: '0.6.1' },
         package_count: 5,
         runs_per_package: 5,
+        warmup_runs: 1,
         aggregate: {
             pyright:  { packages_tested: 5, packages_failed: 0, avg_execution_time_s: 12.5, p90_execution_time_s: 22.0, p95_execution_time_s: 25.0, max_execution_time_s: 30.0, total_execution_time_s: 62.5, avg_peak_memory_mb: 350, p90_peak_memory_mb: 480, p95_peak_memory_mb: 500, max_peak_memory_mb: 550 },
             pyrefly:  { packages_tested: 5, packages_failed: 0, avg_execution_time_s: 3.2, p90_execution_time_s: 5.5, p95_execution_time_s: 6.0, max_execution_time_s: 8.0, total_execution_time_s: 16.0, avg_peak_memory_mb: 280, p90_peak_memory_mb: 380, p95_peak_memory_mb: 400, max_peak_memory_mb: 420 },
@@ -288,8 +290,10 @@ function updateTimestamp(): void {
     if (benchmarkData?.timestamp) {
         const d = new Date(benchmarkData.timestamp);
         const runs = benchmarkData.runs_per_package;
+        const warmup = benchmarkData.warmup_runs;
         const runsStr = runs && runs > 1 ? ` | ${runs} runs per package` : '';
-        el.textContent = `Last updated: ${d.toLocaleDateString()} at ${d.toLocaleTimeString()}${runsStr}`;
+        const warmupStr = warmup && warmup > 0 ? ` (${warmup} warmup)` : '';
+        el.textContent = `Last updated: ${d.toLocaleDateString()} at ${d.toLocaleTimeString()}${runsStr}${warmupStr}`;
     } else {
         el.textContent = 'Demo data';
     }


### PR DESCRIPTION
Averaging over multiple runs reduces noise from OS scheduling and caching variance, giving more stable results for comparison.

- Set --runs default from 1 to 5 in daily_runner CLI
- Update methodology in index.html to reflect multi-run process
- Add runs_per_package to TypeScript interface and display in header
- Update README workflow description