### PR TITLE
Discontinue macOS and Windows CI benchmarks due to high runner costs

### DIFF
--- a/.github/workflows/lsp-benchmark-pr.yml
+++ b/.github/workflows/lsp-benchmark-pr.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 4
 

--- a/.github/workflows/lsp-benchmark.yml
+++ b/.github/workflows/lsp-benchmark.yml
@@ -2,10 +2,8 @@ name: Daily LSP Benchmark
 
 on:
   schedule:
-    # Daily at 3 AM UTC (ubuntu + windows)
+    # Daily at 3 AM UTC (ubuntu only)
     - cron: '0 3 * * *'
-    # Weekly on Tuesdays at 3 AM UTC (macos)
-    - cron: '0 3 * * 2'
   workflow_dispatch:
     inputs:
       package_count:
@@ -22,11 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ fromJSON(
-          github.event_name == 'workflow_dispatch' && '["ubuntu-latest","macos-latest","windows-latest"]' ||
-          github.event.schedule == '0 3 * * 2' && '["macos-latest"]' ||
-          '["ubuntu-latest","windows-latest"]'
-          ) }}
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 360
 

--- a/.github/workflows/typecheck-benchmark.yml
+++ b/.github/workflows/typecheck-benchmark.yml
@@ -2,10 +2,8 @@ name: Daily Type Checker Timing Benchmark
 
 on:
   schedule:
-    # Daily at 5 AM UTC (ubuntu + windows)
+    # Daily at 5 AM UTC (ubuntu only)
     - cron: '0 5 * * *'
-    # Weekly on Wednesdays at 5 AM UTC (macos)
-    - cron: '0 5 * * 3'
   workflow_dispatch:
     inputs:
       package_count:
@@ -18,11 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ fromJSON(
-          github.event_name == 'workflow_dispatch' && '["ubuntu-latest","macos-latest","windows-latest"]' ||
-          github.event.schedule == '0 5 * * 3' && '["macos-latest"]' ||
-          '["ubuntu-latest","windows-latest"]'
-          ) }}
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 480
 

--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,6 @@ typecheck_benchmark/scripts/typecheck-benchmark.js
 .repo-cache/
 .venv*
 analysis
+
+# Local benchmark results
+typecheck_benchmark/results/local-*/

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,0 +1,96 @@
+# Running Benchmarks Locally
+
+Automated macOS and Windows benchmarks have been discontinued. Ubuntu benchmarks continue to run daily via CI. Use this guide to run benchmarks locally on macOS or Windows.
+
+## Prerequisites
+
+- Python 3.12
+- Node.js 20+ (for Pyright)
+- Type checkers installed: `pip install pyrefly ty mypy zuban` and `npm install -g pyright`
+
+## Setup
+
+```bash
+git clone git@github.com:lolpack/type_coverage_py.git
+cd type_coverage_py
+python -m venv .venv
+source .venv/bin/activate   # macOS/Linux
+# .venv\Scripts\activate    # Windows
+pip install -r requirements.txt
+```
+
+## Type Checker Timing Benchmark
+
+Measures wall-clock execution time and peak memory when type checking popular Python packages.
+
+**Run all packages with all checkers (default: 5 runs + 1 warmup):**
+
+```bash
+python -m typecheck_benchmark
+```
+
+**Run with specific options:**
+
+```bash
+# Specific checkers
+python -m typecheck_benchmark --checkers pyrefly pyright
+
+# Specific packages
+python -m typecheck_benchmark --package-names requests flask
+
+# Limit number of packages
+python -m typecheck_benchmark --packages 10
+
+# Custom output directory
+python -m typecheck_benchmark --output typecheck_benchmark/results/local-myplatform
+
+# Adjust runs and warmup
+python -m typecheck_benchmark --runs 3 --warmup 1
+
+# Benchmark a local project directory
+python -m typecheck_benchmark --local /path/to/your/project --checkers pyrefly
+```
+
+**Dashboard:** [https://python-type-checking.com/typecheck_benchmark/](https://python-type-checking.com/typecheck_benchmark/)
+
+## LSP Benchmark
+
+Measures `textDocument/definition` (Go to Definition) latency and accuracy across Python language servers.
+
+**Run all packages with all LSPs (default: 100 runs):**
+
+```bash
+python -m lsp.benchmark.daily_runner
+```
+
+**Run with specific options:**
+
+```bash
+# Specific checkers
+python -m lsp.benchmark.daily_runner --checkers pyrefly pyright
+
+# Limit number of packages
+python -m lsp.benchmark.daily_runner --packages 5
+
+# Custom number of runs
+python -m lsp.benchmark.daily_runner --runs 50
+
+# Custom output directory
+python -m lsp.benchmark.daily_runner --output lsp/benchmark/results/local-myplatform
+```
+
+**Dashboard:** [https://python-type-checking.com/lsp/benchmark/](https://python-type-checking.com/lsp/benchmark/)
+
+## CLI Reference
+
+| Flag | Typecheck | LSP | Description |
+|------|:---------:|:---:|-------------|
+| `--packages N` | Y | Y | Max number of packages to benchmark |
+| `--package-names a b` | Y | N | Specific package names |
+| `--checkers a b` | Y | Y | Which type checkers/LSPs to run |
+| `--runs N` | Y | Y | Number of measured runs (default: 5 / 100) |
+| `--warmup N` | Y | N | Warmup runs to discard (default: 1) |
+| `--output DIR` | Y | Y | Output directory for results |
+| `--os-name NAME` | Y | Y | OS label for output filename |
+| `--timeout N` | Y | N | Timeout per checker in seconds |
+| `--local PATH` | Y | N | Benchmark a local directory |

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Calculate the Type Coverage for top Python packages. This analysis aims to deter
 - Coverage Trends: [https://python-type-checking.com/historical_data/coverage-trends.html](https://python-type-checking.com/historical_data/coverage-trends.html)
 - Prioritized Coverage Reports: [https://python-type-checking.com/prioritized/](https://python-type-checking.com/prioritized/)
 - LSP Performance Benchmark: [https://python-type-checking.com/lsp/benchmark/](https://python-type-checking.com/lsp/benchmark/)
+- Type Checker Timing Benchmark: [https://python-type-checking.com/typecheck_benchmark/](https://python-type-checking.com/typecheck_benchmark/)
 
 - Prioritized list of packages included in analysis with Pyright: https://github.com/lolpack/type_coverage_py/blob/main/included_packages.txt
 - Coverage trends for prioritized list: [https://python-type-checking.com/prioritized/historical_data/coverage-trends.html](https://python-type-checking.com/prioritized/historical_data/coverage-trends.html)
@@ -86,10 +87,12 @@ Runs daily at 8 AM EST. Analyzes the top 2000 PyPI packages for type coverage us
 Runs daily at 10 AM EST. Analyzes a curated list of packages (defined in `included_packages.txt`) with Pyright stats. Generates `prioritized/package_report.json` and daily snapshots in `prioritized/historical_data/json/`. Deploys prioritized data and site files to `published-report`.
 
 ### Daily LSP Benchmark (`lsp-benchmark.yml`)
-Runs daily at 3 AM UTC on Ubuntu and Windows, weekly on Tuesdays for macOS. Benchmarks LSP performance (time-to-first-diagnostic, completions, hover) across Pyright, Pyrefly, ty, and Zuban on the prioritized package list. Each OS produces a separate results JSON. Deploys to `published-report` with retry logic for concurrent matrix job pushes.
+Runs daily at 3 AM UTC on Ubuntu. Benchmarks LSP performance (time-to-first-diagnostic, completions, hover) across Pyright, Pyrefly, ty, and Zuban on the prioritized package list. Deploys to `published-report`.
 
 ### Daily Type Checker Timing Benchmark (`typecheck-benchmark.yml`)
-Runs daily at 5 AM UTC on Ubuntu and Windows, weekly on Wednesdays for macOS. Measures full type-checking time across Pyright, Pyrefly, ty, mypy, and Zuban on packages with install configurations. Each checker is run 5 times per package and results are averaged. Each OS produces a separate results JSON. Deploys to `published-report` with retry logic for concurrent matrix job pushes.
+Runs daily at 5 AM UTC on Ubuntu. Measures full type-checking time across Pyright, Pyrefly, ty, mypy, and Zuban on packages with install configurations. Each checker is run 5 times per package and results are averaged. Deploys to `published-report`.
+
+> **Note:** macOS and Windows CI benchmarks have been discontinued due to high GitHub Actions runner costs. See [BENCHMARKS.md](BENCHMARKS.md) for instructions on running benchmarks locally on those platforms.
 
 ## Development
 

--- a/lsp/benchmark/index.html
+++ b/lsp/benchmark/index.html
@@ -21,8 +21,8 @@
                 <label for="osSelect">Platform:</label>
                 <select id="osSelect" class="filter-select">
                     <option value="ubuntu">Ubuntu</option>
-                    <option value="macos">macOS</option>
-                    <option value="windows">Windows</option>
+                    <option value="macos">macOS (discontinued)</option>
+                    <option value="windows">Windows (discontinued)</option>
                 </select>
                 <label for="dateSelect">Date:</label>
                 <input type="date" id="dateSelect" class="date-input">
@@ -36,6 +36,7 @@
     <nav class="nav-bar">
         <div class="container">
             <a href="/index.html" class="back-link">← Back to Type Coverage</a>
+            <a href="/typecheck_benchmark/" class="back-link">Compare Type Checking Performance</a>
             <div class="nav-links">
                 <a href="#summary">Summary</a>
                 <a href="#comparison">Comparison</a>
@@ -44,6 +45,18 @@
             </div>
         </div>
     </nav>
+
+    <div class="container">
+        <div id="discontinuedBanner" class="method-card" style="display:none; margin-top: 1.5rem; border-left: 4px solid #f59e0b; padding: 1rem 1.5rem;">
+            <h3>macOS &amp; Windows Benchmarks Discontinued</h3>
+            <p>
+                Automated macOS and Windows benchmarks have been discontinued.
+                Historical data for those platforms remains available by selecting past dates.
+                For current macOS or Windows results, benchmarks are best run locally &mdash;
+                see the <a href="https://github.com/lolpack/type_coverage_py/blob/main/BENCHMARKS.md">local benchmark guide</a>.
+            </p>
+        </div>
+    </div>
 
     <main class="container">
         <!-- Run Summary -->
@@ -237,7 +250,7 @@
     <footer class="footer">
         <div class="container">
             <p>Part of the <a href="https://github.com/lolpack/type_coverage_py">Python Type Coverage</a> project</p>
-            <p>Benchmarks run daily via GitHub Actions</p>
+            <p>Benchmarks run daily on Ubuntu via GitHub Actions | <a href="/typecheck_benchmark/">Typecheck Benchmark</a></p>
         </div>
     </footer>
 

--- a/lsp/benchmark/scripts/lsp-benchmark.js
+++ b/lsp/benchmark/scripts/lsp-benchmark.js
@@ -148,6 +148,11 @@ async function init() {
 // ---------------------------------------------------------------------------
 // Date/OS selector
 // ---------------------------------------------------------------------------
+function updateDiscontinuedBanner(os) {
+    const banner = document.getElementById('discontinuedBanner');
+    if (banner)
+        banner.style.display = (os === 'macos' || os === 'windows') ? 'block' : 'none';
+}
 /**
  * Setup date selector event listeners
  */
@@ -189,10 +194,12 @@ function setupDateSelector() {
     if (osSelect) {
         osSelect.addEventListener('change', async () => {
             currentOs = osSelect.value;
+            updateDiscontinuedBanner(currentOs);
             const date = dateInput.value || null;
             await switchToDate(date, currentOs);
         });
     }
+    updateDiscontinuedBanner(currentOs);
 }
 // ---------------------------------------------------------------------------
 // Data loading

--- a/lsp/benchmark/scripts/lsp-benchmark.ts
+++ b/lsp/benchmark/scripts/lsp-benchmark.ts
@@ -215,6 +215,11 @@ async function init(): Promise<void> {
 // Date/OS selector
 // ---------------------------------------------------------------------------
 
+function updateDiscontinuedBanner(os: string): void {
+    const banner = document.getElementById('discontinuedBanner');
+    if (banner) banner.style.display = (os === 'macos' || os === 'windows') ? 'block' : 'none';
+}
+
 /**
  * Setup date selector event listeners
  */
@@ -261,10 +266,12 @@ function setupDateSelector(): void {
     if (osSelect) {
         osSelect.addEventListener('change', async () => {
             currentOs = osSelect.value;
+            updateDiscontinuedBanner(currentOs);
             const date = dateInput.value || null;
             await switchToDate(date, currentOs);
         });
     }
+    updateDiscontinuedBanner(currentOs);
 }
 
 // ---------------------------------------------------------------------------

--- a/typecheck_benchmark/index.html
+++ b/typecheck_benchmark/index.html
@@ -20,8 +20,8 @@
                 <label for="osSelect">Platform:</label>
                 <select id="osSelect" class="filter-select">
                     <option value="ubuntu">Ubuntu</option>
-                    <option value="macos">macOS</option>
-                    <option value="windows">Windows</option>
+                    <option value="macos">macOS (discontinued)</option>
+                    <option value="windows">Windows (discontinued)</option>
                 </select>
                 <label for="dateSelect">Date:</label>
                 <input type="date" id="dateSelect" class="date-input">
@@ -35,6 +35,7 @@
     <nav class="nav-bar">
         <div class="container">
             <a href="/index.html" class="back-link">&larr; Back to Type Coverage</a>
+            <a href="/lsp/benchmark/" class="back-link">Compare LSP Performance</a>
             <div class="nav-links">
                 <a href="#comparison">Comparison</a>
                 <a href="#packages">By Package</a>
@@ -42,6 +43,18 @@
             </div>
         </div>
     </nav>
+
+    <div class="container">
+        <div id="discontinuedBanner" class="method-card" style="display:none; margin-top: 1.5rem; border-left: 4px solid #f59e0b; padding: 1rem 1.5rem;">
+            <h3>macOS &amp; Windows Benchmarks Discontinued</h3>
+            <p>
+                Automated macOS and Windows benchmarks have been discontinued.
+                Historical data for those platforms remains available by selecting past dates.
+                For current macOS or Windows results, benchmarks are best run locally &mdash;
+                see the <a href="https://github.com/lolpack/type_coverage_py/blob/main/BENCHMARKS.md">local benchmark guide</a>.
+            </p>
+        </div>
+    </div>
 
     <main class="container">
         <!-- Failure Summary -->
@@ -291,7 +304,7 @@
     <footer class="footer">
         <div class="container">
             <p>Part of the <a href="https://github.com/lolpack/type_coverage_py">Python Type Coverage</a> project</p>
-            <p>Benchmarks run daily via GitHub Actions</p>
+            <p>Benchmarks run daily on Ubuntu via GitHub Actions | <a href="/lsp/benchmark/">LSP Benchmark</a></p>
         </div>
     </footer>
 

--- a/typecheck_benchmark/scripts/typecheck-benchmark.js
+++ b/typecheck_benchmark/scripts/typecheck-benchmark.js
@@ -141,6 +141,11 @@ function renderAll() {
 // ---------------------------------------------------------------------------
 // Date/OS selector
 // ---------------------------------------------------------------------------
+function updateDiscontinuedBanner(os) {
+    const banner = document.getElementById('discontinuedBanner');
+    if (banner)
+        banner.style.display = (os === 'macos' || os === 'windows') ? 'block' : 'none';
+}
 function setupDateSelector() {
     const dateInput = document.getElementById('dateSelect');
     const loadBtn = document.getElementById('loadDateBtn');
@@ -166,9 +171,11 @@ function setupDateSelector() {
     if (osSelect) {
         osSelect.addEventListener('change', async () => {
             currentOs = osSelect.value;
+            updateDiscontinuedBanner(currentOs);
             await switchToDate(dateInput.value || null, currentOs);
         });
     }
+    updateDiscontinuedBanner(currentOs);
 }
 async function switchToDate(date, os) {
     try {

--- a/typecheck_benchmark/scripts/typecheck-benchmark.ts
+++ b/typecheck_benchmark/scripts/typecheck-benchmark.ts
@@ -205,6 +205,11 @@ function renderAll(): void {
 // Date/OS selector
 // ---------------------------------------------------------------------------
 
+function updateDiscontinuedBanner(os: string): void {
+    const banner = document.getElementById('discontinuedBanner');
+    if (banner) banner.style.display = (os === 'macos' || os === 'windows') ? 'block' : 'none';
+}
+
 function setupDateSelector(): void {
     const dateInput = document.getElementById('dateSelect') as HTMLInputElement | null;
     const loadBtn = document.getElementById('loadDateBtn');
@@ -228,9 +233,11 @@ function setupDateSelector(): void {
     if (osSelect) {
         osSelect.addEventListener('change', async () => {
             currentOs = osSelect.value;
+            updateDiscontinuedBanner(currentOs);
             await switchToDate(dateInput.value || null, currentOs);
         });
     }
+    updateDiscontinuedBanner(currentOs);
 }
 
 async function switchToDate(date: string | null, os: string): Promise<void> {


### PR DESCRIPTION
- Remove macOS/Windows from typecheck-benchmark, lsp-benchmark, and lsp-benchmark-pr workflow matrices (Ubuntu-only going forward)
- Add conditional banner in both benchmark dashboards shown only when macOS or Windows is selected, with link to local benchmark guide
- Add cross-navigation links between LSP and typecheck benchmark pages
- Add BENCHMARKS.md with instructions for running benchmarks locally
- Add typecheck benchmark link to README coverage reports section
- Gitignore local benchmark results (typecheck_benchmark/results/local-*/)